### PR TITLE
Task7-3-e　Niwatoriクラスの更新

### DIFF
--- a/Niwatori.pde
+++ b/Niwatori.pde
@@ -3,4 +3,12 @@ class Niwatori extends AbstractKoma {
   Niwatori(String name, int x, int y, int team, boolean active) {
     super(name, x, y, team, active);
   }
+   boolean canMove(int toX, int toY) {
+    if (!board.bArea.isInThisArea(toX,toY)) return false;
+
+    if (this.team==0 && abs(toX-this.x)<=1 && abs(toY-this.y)<=1 && (this.x-toX+abs(this.y-toY))<2) return true;
+    if (this.team==1 && abs(toX-this.x)<=1 && abs(toY-this.y)<=1 && (toX-this.x+abs(this.y-toY))<2) return true;
+
+    return false;
+  }
 }


### PR DESCRIPTION
Niwatoriクラスに，指定したマスにそのNiwatoriが移動可能であるかをtrue/falseで返すcanMove()メソッドを追加する．

canMove()メソッドでは下記の条件をチェックし，true/falseを返す
移動先の座標(toX, toY)がBaseArea内でなければfalseを返す
Niwatoriは斜め後ろ以外のすべての方向に1マス移動できるため，現在の場所と移動先の関係が斜め後ろでない場合にtrueを返す
上記の条件をどれも満たさない場合はfalseを返す

実装しました。確認お願いします。